### PR TITLE
Fix prettier plugin order

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,5 @@
   "singleQuote": false,
   "endOfLine": "lf",
   "trailingComma": "all",
-  "plugins": ["prettier-plugin-tailwindcss", "prettier-plugin-organize-imports"]
+  "plugins": ["prettier-plugin-organize-imports", "prettier-plugin-tailwindcss"]
 }

--- a/src/lib/components/ThemeToggle.tsx
+++ b/src/lib/components/ThemeToggle.tsx
@@ -18,8 +18,8 @@ export default function ThemeToggle() {
 
   return (
     <Button variant="outline" size="icon" type="button" onClick={toggleTheme}>
-      <SunIcon className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <MoonIcon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <SunIcon className="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+      <MoonIcon className="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   );

--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -8,7 +8,7 @@ function DashboardIndex() {
   return (
     <div className="flex flex-col gap-1">
       Dashboard index page
-      <pre className="rounded-md border bg-card p-1 text-card-foreground">
+      <pre className="bg-card text-card-foreground rounded-md border p-1">
         routes/dashboard/index.tsx
       </pre>
     </div>

--- a/src/routes/dashboard/route.tsx
+++ b/src/routes/dashboard/route.tsx
@@ -20,7 +20,7 @@ function DashboardLayout() {
       <h1 className="text-4xl font-bold">Dashboard Layout</h1>
       <div className="flex items-center gap-2">
         This is a protected layout:
-        <pre className="rounded-md border bg-card p-1 text-card-foreground">
+        <pre className="bg-card text-card-foreground rounded-md border p-1">
           routes/dashboard/route.tsx
         </pre>
       </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -20,7 +20,7 @@ function Home() {
       <h1 className="text-4xl font-bold">React TanStarter</h1>
       <div className="flex items-center gap-2">
         This is an unprotected page:
-        <pre className="rounded-md border bg-card p-1 text-card-foreground">
+        <pre className="bg-card text-card-foreground rounded-md border p-1">
           routes/index.tsx
         </pre>
       </div>
@@ -62,7 +62,7 @@ function Home() {
       <ThemeToggle />
 
       <a
-        className="text-muted-foreground underline hover:text-foreground"
+        className="text-muted-foreground hover:text-foreground underline"
         href="https://github.com/dotnize/react-tanstarter"
         target="_blank"
         rel="noreferrer noopener"

--- a/src/routes/signin.tsx
+++ b/src/routes/signin.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/signin")({
 function AuthPage() {
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <div className="flex flex-col items-center gap-8 rounded-xl border bg-card p-10">
+      <div className="bg-card flex flex-col items-center gap-8 rounded-xl border p-10">
         Logo here
         <div className="flex flex-col gap-2">
           <SignInButton


### PR DESCRIPTION
## Description

- Move `prettier-plugin-tailwindcss` to the end of the plugins array in .prettierrc. ([documentation](https://github.com/tailwindlabs/prettier-plugin-tailwindcss?tab=readme-ov-file#compatibility-with-other-prettier-plugins))
- Run `pnpm format`

## P.S.

Thank you very much for awesome template!