### PR TITLE
refactor: Remove redundant user loader from dashboard route

### DIFF
--- a/src/routes/(authenticated)/dashboard/index.tsx
+++ b/src/routes/(authenticated)/dashboard/index.tsx
@@ -3,13 +3,10 @@ import { SignOutButton } from "~/components/sign-out-button";
 
 export const Route = createFileRoute("/(authenticated)/dashboard/")({
   component: DashboardIndex,
-  loader: ({ context }) => {
-    return { user: context.user };
-  },
 });
 
 function DashboardIndex() {
-  const { user } = Route.useLoaderData();
+  const { user } = Route.useRouteContext();
 
   return (
     <div className="flex flex-col items-center gap-1">
@@ -18,7 +15,7 @@ function DashboardIndex() {
         routes/(authenticated)dashboard/index.tsx
       </pre>
       <div className="mt-2 text-center text-xs sm:text-sm">
-        User data from route loader:
+        User data from route context:
         <pre className="max-w-screen overflow-x-auto px-2 text-start">
           {JSON.stringify(user, null, 2)}
         </pre>


### PR DESCRIPTION
### Summary

This pull request refactors the protected route at `(authenticated)/dashboard/index.tsx` by removing a redundant `loader` function  and updating a related UI string.

### The Problem

The parent route, `(authenticated)/route.tsx`, already fetches the authenticated user to the route context via its beforeLoad function. This is done by awaiting `context.queryClient.ensureQueryData` and returning the user.

However, the child dashboard index route had a completely redundant loader function that simply returned the user from the context without any additional logic or data fetching.

Furthermore, a debugging string in the UI stated "User data from route loader," which was misleading, as the user data was not originating from the dashboard's loader but from the parent route's context.

### The Solution

* Removed the redundant `loader` from `(authenticated)/dashboard/index.tsx`.
* Updated the dashboard component to access user data directly from the route context using `Route.useRouteContext()` instead of `Route.useLoaderData()`.
* Corrected the UI text from "User data from route loader" to "User data from context" to accurately describe the data's source.