### PR TITLE
Update Better Auth to use tanstackStartCookies plugin

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -1,7 +1,7 @@
 import { createServerOnlyFn } from "@tanstack/react-start";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { reactStartCookies } from "better-auth/react-start";
+import { tanstackStartCookies } from "better-auth/tanstack-start";
 
 import { env } from "~/env/server";
 import { db } from "~/lib/db";
@@ -17,7 +17,7 @@ const getAuthConfig = createServerOnlyFn(() =>
     }),
 
     // https://www.better-auth.com/docs/integrations/tanstack#usage-tips
-    plugins: [reactStartCookies()],
+    plugins: [tanstackStartCookies()],
 
     // https://www.better-auth.com/docs/concepts/session-management#session-caching
     session: {


### PR DESCRIPTION
## Fix: Update Better Auth to use tanstackStartCookies plugin

Fixes compatibility by switching from the deprecated `reactStartCookies` to `tanstackStartCookies` per Better Auth docs.

### Changes
- Updated import path: `better-auth/react-start` → `better-auth/tanstack-start`
- Updated plugin: `reactStartCookies()` → `tanstackStartCookies()`

### Files changed
- `src/lib/auth/auth.ts`

This resolves authentication issues when testing the template.

<img width="533" height="71" alt="Screenshot 2025-11-22 at 04 21 25" src="https://github.com/user-attachments/assets/acf2842d-d186-4e72-b1df-d90949dd797e" />
